### PR TITLE
Restore syntax highlighting.

### DIFF
--- a/turo-web/src/Results.js
+++ b/turo-web/src/Results.js
@@ -7,7 +7,7 @@ class Result extends PureComponent {
     const padding = this.props.pad;
     return (
       <div>
-        { times(padding, i => ( <EmptyResult /> )) }
+        { times(padding, i => ( <EmptyResult key={this.props.id + '--' + i} /> )) }
         <div contentEditable={false} className='statement__result'>
           <span>{this.props.result}</span>
         </div>
@@ -31,7 +31,7 @@ export default class Results extends PureComponent {
   render() {
     return (<div className='results'>
       {this.props.statements.map(stat => (
-        <Result key={stat.id} result={stat.valueToString()} pad={stat.info.lineLast - stat.info.lineFirst} />
+        <Result key={stat.id} id={stat.id} result={stat.valueToString()} pad={stat.info.lineLast - stat.info.lineFirst} />
       ))}
     </div>);
   }

--- a/turo-web/src/decorator.js
+++ b/turo-web/src/decorator.js
@@ -4,8 +4,7 @@ import store from './store';
 import { docStore } from './reducer';
 
 const tokens = [];
-[
-  {
+[  {
     token: 'number',
     className: 'token--number'
   },
@@ -28,17 +27,33 @@ const createComp = ({ className }) => props => (<span className={className}>
 </span>);
 
 const createStrategy = ({ token }) => (contentBlock, callback) => {
-  if (!docStore.turoDoc) return ;
-  let statement = docStore.turoDoc.evaluateStatement(contentBlock.key, contentBlock.getText());
-  if (!statement || !statement[0].tokens) return ;
-  statement = statement[0];
-  const textLength = contentBlock.getText().length;
-  const tokens = statement.tokens.filter(tok => tok.displayType === token);
+  
+  const tokenMap = docStore.tokenMap;
+  if (!tokenMap) {
+    console.log('NO TOKEN MAP');
+    return;
+  }
 
-  tokens.forEach(token => {
-    let end = token.startOffset + token.literal.length;
-    end = end > textLength ? textLength : end;
-    callback(token.startOffset, end)
+  console.log('Decorator using tokenMap');
+
+  if (!tokenMap[contentBlock.getKey()]) {
+    console.log('Not good:', contentBlock.getKey(), "not in", Object.keys(tokenMap));
+    return;
+  }
+  
+  const text = contentBlock.getText();
+  const lineLength = text.length;
+  const unfilteredTokens = tokenMap[contentBlock.getKey()] || [];
+
+  const tokens = unfilteredTokens.filter(tok => tok.displayType === token);
+
+  console.log(`${contentBlock.getKey()} block: highlighting ${tokens.length} ${token} tokens`);
+
+  tokens.forEach(t => {
+    const start = t.startOffset;
+    const end = Math.min(start + t.literal.length, lineLength);
+    console.log('\thighlighting', text.substring(start, end));
+    callback(start, end)
   });
 }
 

--- a/turo/lib/document/turo-statement.js
+++ b/turo/lib/document/turo-statement.js
@@ -100,10 +100,7 @@ _.extend(TuroStatement.prototype, {
   },
 
   toTokens() {
-    return toTokenArray(this.node).map(token => ({
-      ...token,
-      startOffset: token.startOffset > -1 ? token.startOffset - this.info.offsetFirst: token.startOffset,
-    }));
+    return toTokenArray(this.node);
   },
 
   valueToString (display, prefs) {

--- a/turo/lib/grammar.pegjs
+++ b/turo/lib/grammar.pegjs
@@ -258,7 +258,7 @@ UnitExpression =
     for (var i=0; i<tail.length; i++) {
       op = tail[i][0];
       unitNode = new ast.UnitMultOp(helper.infixAliases[op.opName] || op.opName, unitNode, tail[i][1]);
-      helper.decorateNonTerminal(unitNode, op.offset, op.literal);
+      helper.decorateNonTerminal(unitNode, op.line, op.offset, op.literal);
     }
 
     op = optionalPer ? optionalPer[0] : optionalPer;
@@ -266,7 +266,7 @@ UnitExpression =
     if (op) {
       unitNode = new ast.UnitMultOp('/', null, unitNode);
       unitNode._offsetFirst = offset;
-      helper.decorateNonTerminal(unitNode, op.offset, op.literal);
+      helper.decorateNonTerminal(unitNode, op.line, op.offset, op.literal);
     }
     return unitNode;
 }
@@ -277,6 +277,7 @@ UnitMultiplicativeOperator =
       const { offset, line } = location().start;
       return {
         offset: offset,
+        line: line,
         literal: space,
         opName: '*',
       };
@@ -289,6 +290,7 @@ UnitPer "unitPer"
 
     return {
       offset: offset,
+      line: line,
       literal: literal,
       opName: '/'
     };
@@ -301,7 +303,7 @@ UnitPerLiteral
 UnitMultiplier 
   = unitNode:UnitIdentifier _ op:RaiseToPowerOperator _ num:IntegerNode { 
       var node = new ast.UnitPowerNode(unitNode, num); 
-      return helper.decorateNonTerminal(node, op.offset, op.literal);
+      return helper.decorateNonTerminal(node, op.line, op.offset, op.literal);
     }
   / unitNode:UnitIdentifier {
       return unitNode;
@@ -315,6 +317,7 @@ RaiseToPowerOperator "unitPower"
     return {
       literal: literal,
       offset: offset,
+      line: line,
     }
   }
   
@@ -326,7 +329,7 @@ UnitIdentifier "unit" = unitName:UnitIdentifierLiteral &{ return !!parseContext.
   var node = new ast.UnitLiteralNode(parseContext.scope.findUnit(unitName), unitName);
   const { offset, line } = location().start;
 
-  return helper.decorateTerminal(node, offset, unitName);
+  return helper.decorateTerminal(node, line, offset, unitName);
  }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -392,7 +395,7 @@ NumbericalExpressionUnitConversion =
       var op = unitConversion[0],
           unitNode = unitConversion[1];
       node = new ast.BinaryNode(node, unitNode, op.literal);
-      helper.decorateNonTerminal(node, op.offset, op.literal); 
+      helper.decorateNonTerminal(node, op.line, op.offset, op.literal); 
     }
     return node;
   }
@@ -606,7 +609,7 @@ ValueOrParens
     {
       const { offset, line } = location().start;
 
-      return helper.decorateTerminal(t, offset, t.literal || t.name);
+      return helper.decorateTerminal(t, line, offset, t.literal || t.name);
     }
   / po:ParensOpen _ expression:NumericalExpression _ pc:ParensClose
     {
@@ -738,7 +741,7 @@ IntegerNode = number:IntegerString {
   var node = new ast.NumberNode(number);
   const { offset, line } = location().start;
 
-  return helper.decorateTerminal(node, offset, number);
+  return helper.decorateTerminal(node, line, offset, number);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/turo/lib/parser-helper.js
+++ b/turo/lib/parser-helper.js
@@ -19,19 +19,21 @@ var unaryAliases = {
   '√': 'sqrt',
 };
 
-function decorateTerminal (node, offset, string) {
+function decorateTerminal (node, line, offset, string) {
   var last = offset + string.length - 1;
   node._offsetFirst = offset;
   node._offsetLast = last; 
   node._offsetLiteralFirst = offset;
   node._offsetLiteralLast = last;
+  node.line = line;
   return node;
 }
 
-function decorateNonTerminal(node, offset, string) {
+function decorateNonTerminal(node, line, offset, string) {
   var last = offset + string.length - 1;
   node._offsetLiteralFirst = offset;
   node._offsetLiteralLast = last;
+  node.line = line;
   return node;
 }
 
@@ -61,7 +63,7 @@ function unpackLeftBinaryOperations(head, tail) {
     op = tail[i][1];
     result = new ast.BinaryNode(result, tail[i][3], infixAliases[op.literal] || op.literal);
 
-    decorateNonTerminal(result, op.offset, op.literal);
+    decorateNonTerminal(result, op.line, op.offset, op.literal);
   }
   return result;
 }
@@ -85,12 +87,12 @@ function unpackRightBinaryOperations(head, tail) {
     } else {
       left = tail[i][3];
       result = new ast.BinaryNode(left, result, infixAliases[op.literal] || op.literal);
-      decorateNonTerminal(result, op.offset, op.literal);
+      decorateNonTerminal(result, op.line, op.offset, op.literal);
       op = tail[i][1];
     }
   }
   result = new ast.BinaryNode(head, result, infixAliases[op.literal] || op.literal);
-  return decorateNonTerminal(result, op.offset, op.literal);
+  return decorateNonTerminal(result, op.line, op.offset, op.literal);
 }
 
 function unpackUnaryOperations(current, operators, isPrefix) {
@@ -104,6 +106,7 @@ function unpackUnaryOperations(current, operators, isPrefix) {
     op = operators[i][literalIndex];
     current = new ast.UnaryOperationNode(current, unaryAliases[op.literal] || op.literal, isPrefix);
 
+    current.line = op.line;
     current._offsetLiteralFirst = op.offset;
     current._offsetLiteralLast = op.offset + op.literal.length - 1;
 


### PR DESCRIPTION
Currently we're having the problem that draft-js does decorating as the _first_ thing after an update. 

This makes sense for rich text editing, where there is very little to update, but makes no sense for languages that want to can detect errors and want to display them.

A further difficulty here is that statements may fit over more than one editor block. 

The first commit here brings assembles a `tokenMap` — a map of editor block `key` to an array of token objects. Given a valid edit block, the decorator strategy should be able to filter the tokens it's interested in (including errors), and then decorate accordingly. The `tokenMap` is being assembled from the parse tree and evaluator, which means we're always a tick away with the current strategy.