### PR TITLE
Fixup detection of cycles in document-model, and better error reporting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "babel-preset-react-app": "^3.1.0"
   },
   "scripts": {
-    "install-all": "cd turo && yarn && cd ../turo-web && yarn && cd .."
+    "install-all": "cd turo && yarn && cd ../turo-react && yarn && cd .."
   }
 }

--- a/turo/lib/ast.js
+++ b/turo/lib/ast.js
@@ -104,7 +104,9 @@ function defineClone (Ctor) {
 }
 
 function TuroError (errorMessage, node) {
+  // deprecated, use errorCode.
   this.message = errorMessage;
+  this.errorCode = errorMessage;
   this.node = node;
 }
 

--- a/turo/lib/document/document-model.js
+++ b/turo/lib/document/document-model.js
@@ -179,9 +179,14 @@ _.extend(DocumentModel.prototype, {
       state: State.OK,
       scope: finalScope,
     };
-    var idsInEvalOrder = this._cascade(g.execution, statementMap);
-    this._evaluateNodes(idsInEvalOrder, statementMap);
-    return this._finalReturn(ids);
+    try {
+      var idsInEvalOrder = this._cascade(g.execution, statementMap);
+      this._evaluateNodes(idsInEvalOrder, statementMap);
+    } catch (e) {
+      console.log(e);
+    } finally {
+      return this._finalReturn(ids);
+    }
   },
 
   /**

--- a/turo/lib/evaluator.js
+++ b/turo/lib/evaluator.js
@@ -141,19 +141,11 @@ extend(Evaluator.prototype, {
     }
   },
 
-  reportError: function (errorCode, highlightedNode) {
-    var currentOperation = this._currentOperationNode, 
-        error = new ast.Error(errorCode, currentOperation);
-
-    if (currentOperation) {
-      currentOperation.error = error;
-    }
-
-    for (var i = 1, max = arguments.length; i < max; i++) {
-      arguments[i].error = error;
-    }
-
-    this.errors.push(error);
+  reportError: function (errorCode, ...highlightedNodes) {
+    highlightedNodes.forEach(node => {
+      const error = new ast.Error(errorCode, node);
+      this.errors.push(error);
+    });
   },
 });
 

--- a/turo/package.json
+++ b/turo/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "async": "~0.9.0",
     "babel-tap": "^5.0.0",
-    "dependency-graph": "~0.1.0",
+    "dependency-graph": "~0.7.0",
     "turo-docs": "github:jhugman/turo-docs",
     "underscore": "~1.4.4"
   },

--- a/turo/test/index.js
+++ b/turo/test/index.js
@@ -30,6 +30,7 @@ import './test-integration-grammar';
 import './test-integration-operation-labeller';
 import './test-integration-revaluation-with-different-units';
 import './test-integration-variable-units';
+import './test-integration-errors';
 import './test-percent-arithmetic';
 import './test-trig-functions';
 import './test-unit-schemes';

--- a/turo/test/test-document-model.js
+++ b/turo/test/test-document-model.js
@@ -69,6 +69,17 @@ test('Batch mode', function (t) {
   t.end();
 });
 
+test('Batch mode, part II', function (t) {
+  createModel();
+  testLines(t, ['x = ', '1'], ['1']);
+  testLines(t, ['x = ', 'x'], ['', '']);
+  // x is defined twice, tho the second definition is ignored.
+  testLines(t, ['x = 1', 'y = 2', 'x = x + 1'], ['1', '2', '2']);
+  testLines(t, ['y = x + 1', 'x = y + 2'], ['', '']);
+
+  t.end();
+});
+
 test('Find statement by line', function (t) {
   var lines = ['x = 1', 'y - x + z', 'y = 3', 'z = y - 3 * x'];
   var expectedList = ['1', '2', '3', '0'];

--- a/turo/test/test-error-reporting.js
+++ b/turo/test/test-error-reporting.js
@@ -59,12 +59,12 @@ test("Dimension mismatch", (t) => {
   result = turo.evaluate("1 m + 1 s");
   errors = result.errors;
   t.ok(errors);
-  t.equal(errors.length, 1);
+  t.equal(errors.length, 2);
 
   result = turo.evaluate("(1 m + 1 s) * (1m + 1s)");
   errors = result.errors;
   t.ok(errors);
-  t.equal(errors.length, 2);
+  t.equal(errors.length, 4);
 
   t.end();
 });

--- a/turo/test/test-integration-errors.js
+++ b/turo/test/test-integration-errors.js
@@ -1,0 +1,70 @@
+import { test } from 'tap';
+import _ from 'underscore';
+
+import { storage } from '../lib/storage/app-bundle-storage';
+import { EditableDocument } from '..';
+
+const TuroDocument = EditableDocument;
+TuroDocument.storage = storage;
+
+test('happy case async await', async (t) => {
+  const doc = TuroDocument.create('test2');
+
+  const documentString = [
+    'width = 2 m', 
+    'height = 1m',
+    'area = width * height / 2',
+  ].join('\n');
+
+  await doc.import('fundamental');
+  await doc.evaluateDocument(documentString);
+
+  const results = doc.statements.map(s => s.valueToString());
+
+  t.deepEqual(['2 metres', '1 metre', '1 m^2'], results, 'No errors reported');
+  t.end();
+});
+
+test('error reporting', async (t) => {
+  const doc = TuroDocument.create('test2');
+
+  const documentString = [
+    'height = 2m',
+    'width = 2m + 2s',
+    '1 / (3 - 2 - 1)',
+  ].join('\n');
+
+  await doc.import('fundamental');
+  await doc.evaluateDocument(documentString);
+
+  const results = doc.statements.map(s => s.errors || []);
+
+  t.deepEqual([0, 2, 1], results.map(errors => errors.length), 'Number of errors per statement');
+
+  // error codes
+  t.deepEqual([
+      [],
+      ['DIMENSION_MISMATCH', 'DIMENSION_MISMATCH'],
+      ['DIVIDE_BY_ZERO']
+    ], 
+    results.map(errors => errors.map(e => e.errorCode)), 'Error codes per error per statement');
+
+    // character offsets into the document
+    t.deepEqual([
+      [],
+      [[20, 21], [25, 26]],
+      [[32, 42]]
+    ], 
+    results.map(errors => errors.map(e => [e.node.offsetFirst, e.node.offsetLast])), 'Character offsets per error per statement');
+
+    // statement line offsets
+    // t.deepEqual([
+    //   [1, 1],
+    //   [2, 2],
+    //   [3, 3]
+    // ], 
+    // doc.statements.map(s => [s.offsetFirst, s.offsetLast]), 'Line numbers per statement');
+
+
+  t.end();
+});

--- a/turo/yarn.lock
+++ b/turo/yarn.lock
@@ -1308,11 +1308,9 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-dependency-graph@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.1.0.tgz#caec587b27b0c57d3fb6de5676c878ab251add87"
-  dependencies:
-    underscore "1.4.4"
+dependency-graph@~0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.7.2.tgz#91db9de6eb72699209d88aea4c1fd5221cac1c49"
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -3801,7 +3799,7 @@ underscore.string@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
 
-underscore@1.4.4, underscore@1.4.x, underscore@~1.4.4:
+underscore@1.4.x, underscore@~1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
 


### PR DESCRIPTION
This PR starts reporting error messages with nodes.

The nodes themselves have `offsetFirst` and `offsetLast`. These are character-into-the-document offsets. 

Current limitations: 

 * error node offsets will only be accurate for `evaluateDocument`, not `evaluateStatement`.
 * no line/columns. This is possible, but needs some threading the needle from the parser. 
 * no cycle errors. We can now trap them, but we can't report them until [we get the cycles from `dependency-graph`][1].

[1]: https://github.com/jriecken/dependency-graph/pull/30